### PR TITLE
Fixes dependencies and libraries

### DIFF
--- a/Banana_Pi_M2Z_GPIO.sh
+++ b/Banana_Pi_M2Z_GPIO.sh
@@ -68,7 +68,7 @@ libsdl-ttf2.0-dev \
 libsdl-mixer1.2-dev \
 libsdl-image1.2-dev \
 libjpeg-dev \
-python-dev \
+python3-dev \
 lm-sensors \
 unrar \
 libgpiod2 \
@@ -89,8 +89,8 @@ echo ''
 
 sleep 2s
 
-sudo pip install setuptools==58.3.0
-sudo pip install wheel==0.37.0
+sudo pip3 install setuptools==58.3.0
+sudo pip3 install wheel==0.37.0
 sudo pip3 install pyserial==3.5
 sudo pip3 install pyusb==1.2.1
 sudo pip3 install pyftdi==0.54.0


### PR DESCRIPTION
I don't know if wheel should be instaled using pip of python 2.7 or python 3, so, i chaged to pip3
setuptools require python3
python-dev should be python3-dev
